### PR TITLE
Rename OrderProfile component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename component `OrderProfile` to `OrderProfileProvider`.
+
 ## [0.1.0] - 2020-03-04
 
 ### Added

--- a/react/OrderProfile.tsx
+++ b/react/OrderProfile.tsx
@@ -27,7 +27,7 @@ interface UpdateOrderFormProfileMutationVariables {
 
 const SET_PROFILE_TASK = 'SetProfileTask'
 
-export const OrderProfile: React.FC = ({ children }) => {
+export const OrderProfileProvider: React.FC = ({ children }) => {
   const { enqueue, listen } = useOrderQueue()
   const { setOrderForm } = useOrderForm()
 
@@ -88,4 +88,4 @@ export const useOrderProfile = () => {
   return context
 }
 
-export default { OrderProfile, useOrderProfile }
+export default { OrderProfileProvider, useOrderProfile }


### PR DESCRIPTION
#### What problem is this solving?
Rename the component provider for the order profile to `OrderProfileProvider`, so it matches our other providers.

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->