### PR TITLE
Add function to set the client preferences data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Function to update the client preferences data.
+
 ## [0.1.1] - 2020-03-09
 
 ### Changed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vtex-apps/checkout-ui

--- a/react/OrderProfile.tsx
+++ b/react/OrderProfile.tsx
@@ -1,16 +1,24 @@
 import React, { useMemo, useContext, useCallback } from 'react'
 import { useMutation } from 'react-apollo'
 import MutationUpdateOrderFormProfile from 'vtex.checkout-resources/MutationUpdateOrderFormProfile'
+import MutationUpdateClientPreferencesData from 'vtex.checkout-resources/MutationUpdateClientPreferencesData'
 import {
   useOrderQueue,
   useQueueStatus,
   QueueStatus,
 } from 'vtex.order-manager/OrderQueue'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
-import { OrderForm, UserProfileInput } from 'vtex.checkout-graphql'
+import {
+  OrderForm,
+  UserProfileInput,
+  ClientPreferencesDataInput,
+} from 'vtex.checkout-graphql'
 
 interface ProfileContext {
   setOrderProfile: (profile: UserProfileInput) => Promise<{ success: boolean }>
+  setClientPreferencesData: (
+    clientPreferences: ClientPreferencesDataInput
+  ) => Promise<{ success: boolean }>
 }
 
 const OrderProfileContext = React.createContext<ProfileContext | undefined>(
@@ -25,7 +33,16 @@ interface UpdateOrderFormProfileMutationVariables {
   profile: UserProfileInput
 }
 
+interface UpdateClientPreferencesDataMutation {
+  updateClientPreferencesData: OrderForm
+}
+
+interface UpdateClientPreferencesDataMutationVariables {
+  clientPreferences: ClientPreferencesDataInput
+}
+
 const SET_PROFILE_TASK = 'SetProfileTask'
+const SET_CLIENT_PREFERENCES_TASK = 'SetClientPreferencesTask'
 
 export const OrderProfileProvider: React.FC = ({ children }) => {
   const { enqueue, listen } = useOrderQueue()
@@ -37,6 +54,10 @@ export const OrderProfileProvider: React.FC = ({ children }) => {
     UpdateOrderFormProfileMutation,
     UpdateOrderFormProfileMutationVariables
   >(MutationUpdateOrderFormProfile)
+  const [updateClientPreferencesData] = useMutation<
+    UpdateClientPreferencesDataMutation,
+    UpdateClientPreferencesDataMutationVariables
+  >(MutationUpdateClientPreferencesData)
 
   const setOrderProfile = useCallback(
     async (profile: UserProfileInput) => {
@@ -69,7 +90,37 @@ export const OrderProfileProvider: React.FC = ({ children }) => {
     [updateOrderFormProfile, enqueue, queueStatusRef, setOrderForm]
   )
 
-  const value = useMemo(() => ({ setOrderProfile }), [setOrderProfile])
+  const setClientPreferencesData = useCallback(
+    async (clientPreferences: ClientPreferencesDataInput) => {
+      const task = async () => {
+        const { data } = await updateClientPreferencesData({
+          variables: { clientPreferences },
+        })
+
+        const orderForm = data!.updateClientPreferencesData
+
+        return orderForm
+      }
+
+      try {
+        const newOrderForm = await enqueue(task, SET_CLIENT_PREFERENCES_TASK)
+
+        if (queueStatusRef.current === QueueStatus.FULFILLED) {
+          setOrderForm(newOrderForm)
+        }
+
+        return { success: true }
+      } catch (err) {
+        return { success: false }
+      }
+    },
+    [enqueue, queueStatusRef, setOrderForm, updateClientPreferencesData]
+  )
+
+  const value = useMemo(() => ({ setOrderProfile, setClientPreferencesData }), [
+    setOrderProfile,
+    setClientPreferencesData,
+  ])
 
   return (
     <OrderProfileContext.Provider value={value}>

--- a/react/package.json
+++ b/react/package.json
@@ -14,9 +14,9 @@
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "@vtex/test-tools": "^3.0.3",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql",
-    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.2/public/@types/vtex.checkout-resources",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.0/public/@types/vtex.order-manager",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime"
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.27.0/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.23.0/public/@types/vtex.checkout-resources",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime"
   }
 }

--- a/react/typings/vtex.checkout-resources.d.ts
+++ b/react/typings/vtex.checkout-resources.d.ts
@@ -1,3 +1,9 @@
+/* eslint-disable import/export */
+
 declare module 'vtex.checkout-resources/MutationUpdateOrderFormProfile' {
   export { default } from 'vtex.checkout-resources/react/MutationUpdateOrderFormProfile'
+}
+
+declare module 'vtex.checkout-resources/MutationUpdateClientPreferencesData' {
+  export { default } from 'vtex.checkout-resources/react/MutationUpdateClientPreferencesData'
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4422,21 +4422,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql":
-  version "0.24.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.24.1/public/@types/vtex.checkout-graphql#e970aec45ec8062587fc7d1ad73a6b93ab2ea26a"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.27.0/public/@types/vtex.checkout-graphql":
+  version "0.27.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.27.0/public/@types/vtex.checkout-graphql#f709fa9418c3019d9e461b0203c602c26598ae7e"
 
-"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.2/public/@types/vtex.checkout-resources":
-  version "0.20.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.20.2/public/@types/vtex.checkout-resources#92d3eab8fd9d1d3ebfdb56cdf9495aac565b0092"
+"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.23.0/public/@types/vtex.checkout-resources":
+  version "0.23.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.23.0/public/@types/vtex.checkout-resources#57c59555cf0c3af190f5fe3161b2cadb418426eb"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.0/public/@types/vtex.order-manager":
-  version "0.8.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.0/public/@types/vtex.order-manager#c2246db14b75b10cdeafee1636de310bff746d6c"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager":
+  version "0.8.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager#99a926da2acbfe7612306be3648228cf3469ce45"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime":
-  version "8.94.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime#e79eb9a66801476b66e7ed354a83a7ff1f1c72c7"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime":
+  version "8.95.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime#3aae291d0cd239d3059ea8ae8c3c2800ce36d22f"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What problem is this solving?
Adds a function to the `OrderProfile` context to set the client preferences data. This PR depends on vtex-apps/checkout-resources#38

[Related clubhouse story](https://app.clubhouse.io/vtex/story/32825/criar-componentes-de-profile-form-e-profile-preview)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout/#profile)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->